### PR TITLE
Update MigrationHelper

### DIFF
--- a/library/src/main/java/com/github/yuweiguocn/library/greendao/MigrationHelper.java
+++ b/library/src/main/java/com/github/yuweiguocn/library/greendao/MigrationHelper.java
@@ -190,7 +190,7 @@ public final class MigrationHelper {
                 for (int j = 0; j < daoConfig.properties.length; j++) {
                     String columnName = daoConfig.properties[j].columnName;
                     if (columns.contains(columnName)) {
-                        properties.add(columnName);
+                        properties.add("`" + columnName + "`");
                     }
                 }
                 if (properties.size() > 0) {


### PR DESCRIPTION
Fixed the issue of using the reserved words as column names.
For example when you have a column named ORDER in your table, the current code is going to throw an SQLiteException containing this message:
> 【Failed to restore data from temp table 】BOOK_TEMP
> android.database.sqlite.SQLiteException: near "ORDER": syntax error (code 1): , while compiling:
> REPLACE INTO BOOK (_id,ORDER,TITLE) SELECT _id,ORDER,TITLE FROM BOOK_TEMP;
